### PR TITLE
添加能导出html和pdf内容

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -4,6 +4,7 @@ site_description: 'MaxKB 在线文档'
 site_author: '飞致云'
 repo_name: 'MaxKB'
 repo_url: 'https://github.com/1Panel-dev/MaxKB'
+use_directory_urls: false
 
 edit_uri: https://github.com/1Panel-dev/MaxKB-docs
 theme:
@@ -186,6 +187,10 @@ plugins:
               - en
               - ja
           separator: '[\s\-\.]+'
+    - print-site:
+          enumerate_headings: false
+          enumerate_figures: false
+          toc_title: "目录"
 extra:
     version:
       provider: mike


### PR DESCRIPTION
1.添加了 use_directory_urls: false 参数，执行mkdocs build，即可生成 site的目录
<img width="1005" height="621" alt="image" src="https://github.com/user-attachments/assets/6e1a65e4-5c2e-4df2-9552-85772e32fc68" />
2.安装插件 pip install mkdocs-print-site-plugin -i https://pypi.tuna.tsinghua.edu.cn/simple
然后在 plugins 添加了
- print-site:
      enumerate_headings: false
      enumerate_figures: false
      toc_title: "目录"
执行 mkdocs serve，在页面上访问 http://IP:8000/docs/print_page/，在浏览器页面 右键-打印-保存为 pdf 即可导出pdf文件